### PR TITLE
fix: Target EPOC32 explicitly

### DIFF
--- a/Thoughts/Thoughts.pkg
+++ b/Thoughts/Thoughts.pkg
@@ -1,3 +1,4 @@
+; target: epoc32
 &EN
 #{"Thoughts"},(0x100092ca),0,0,0
 


### PR DESCRIPTION
This change adopts the new platform prefix supported by OpoLua.
